### PR TITLE
Some IPv6 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ multicast setups.
 ## SYNOPSIS
 
 	msend [-g GROUP] [-p PORT] [-join] [-t TTL] [-i ADDRESS] [-P PERIOD]
-	      [-text "text" | -n]
+	      [-I INTERFACE] [-text "text" | -n]
 	msend [-v|-h]
-	mreceive [-g group] [-p port] [-i ip] ... [-i ip] [-n]
+	mreceive [-g group] [-p port] [-i ip] ... [-i ip] [-I INTERFACE] [-n]
 	mreceive [-v|-h]
 
 ## DESCRIPTION
@@ -34,7 +34,8 @@ group:port combination by the `msend` command.
 * `-g GROUP`
 
   Specify the IP multicast group address to which packets are sent, or
-  received.  The default group is 224.1.1.1.
+  received.  The default group is 224.1.1.1 for IPv4 and FF02::1:1 for
+  IPv6.
 
 * `-p PORT`
 
@@ -58,6 +59,11 @@ group:port combination by the `msend` command.
   For `mreceive` one or more interfaces can be given.  The default value
   is `INADDR_ANY` which implies that the default interface selected by
   the system will be used.
+
+* `-I INTERFACE`
+
+  Specify the interface to send on. Can be specified as an alternative
+  to -i.
 
 * `-P PERIOD`
 
@@ -83,4 +89,3 @@ group:port combination by the `msend` command.
 * `-h`
 
   Print the command usage.
-

--- a/msend.c
+++ b/msend.c
@@ -43,7 +43,10 @@
 #define LOOPMAX   20
 #define BUFSIZE   1024
 
-char *TEST_ADDR = "224.1.1.1";
+#define TEST_ADDR_IPV4 "224.1.1.1"
+#define TEST_ADDR_IPV6 "FF02::1:1"
+
+char *TEST_ADDR = NULL;
 int TEST_PORT = 4444;
 int TTL_VALUE = 1;
 int SLEEP_TIME = 1000;
@@ -68,7 +71,8 @@ Usage:  msend [-g GROUP] [-p PORT] [-join] [-i ADDRESS] [-t TTL] [-P PERIOD]\n\
 	      [-text \"text\"|-n]\n\
 	msend [-v | -h]\n\
 \n\
-  -g GROUP     IP multicast group address to send to.  Default: 224.1.1.1\n\
+  -g GROUP     IP multicast group address to send to.\n\
+               Default: IPv4: 224.1.1.1, IPv6: FF02::1:1\n\
   -p PORT      UDP port number used in the multicast packets.  Default: 4444\n\
   -i ADDRESS   IP address of the interface to use to send the packets.\n\
                The default is to use the system default interface.\n\
@@ -190,6 +194,15 @@ int main(int argc, char *argv[])
 			printHelp();
 			return 1;
 		}
+	}
+
+	if(TEST_ADDR == NULL) {
+		if(saddr->family == AF_INET)
+			TEST_ADDR = TEST_ADDR_IPV4;
+		else if(saddr->family == AF_INET6)
+			TEST_ADDR = TEST_ADDR_IPV6;
+		else
+			exit(1);
 	}
 
 	ret = ip_address_parse(TEST_ADDR, &mc);


### PR DESCRIPTION
msend: If using using an IPv6 address to select interface (-i) use an IPv6 group as default
README: Update with new flag -I and add default IPv6 group for msend