### PR TITLE
Bind to port after binding to device

### DIFF
--- a/common.c
+++ b/common.c
@@ -79,13 +79,13 @@ int socket_create(struct sock *s, int family, int port,
 			close(fd);
 			return ret;
 		}
-	} else {
-		ret = bind(fd, serv_addr, s->addr_size);
-		if (ret) {
-			perror("bind");
-			close(fd);
-			return ret;
-		}
+	}
+
+	ret = bind(fd, serv_addr, s->addr_size);
+	if (ret) {
+		perror("bind");
+		close(fd);
+		return ret;
 	}
 
 	s->fd = fd;


### PR DESCRIPTION
This is required to be able to specify port when -I is used.