### PR TITLE
Makefile: make datadir editable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ CPPFLAGS   += -DVERSION=\"$(VERSION)\"
 CFLAGS     += -W -Wall -Wextra -g
 
 prefix     ?= /usr/local
-datadir     = $(prefix)/share/doc/mtools
+datadir    ?= $(prefix)/share/doc/mtools
 mandir      = $(prefix)/share/man/man8
 
 # ttcp is currently not part of the distribution because its not tested


### PR DESCRIPTION
Currently, the `datadir` is hardcoded to `share/doc/mtools`. However, multiple tools named "mtools" exist (e.g., `GNU mtools`), which can cause conflicts. When packaging this version of mtools, we have to rename it (e.g., to mcast-tools) to avoid clashes.

Since the `datadir` is hardcoded, it can't be adjusted during packaging, leading to documentation field validation failures. This patch makes the datadir editable, allowing packagers to modify it as needed.

Close #6 